### PR TITLE
Added new QMP commands for the ability to temporarily close and reopen images

### DIFF
--- a/SOURCES/qemu-dp-2.10.2-add_x-blockdev-suspend_x-blockdev-resume_qmp_commands.XCP-ng.patch
+++ b/SOURCES/qemu-dp-2.10.2-add_x-blockdev-suspend_x-blockdev-resume_qmp_commands.XCP-ng.patch
@@ -1,0 +1,83 @@
+diff --git a/qapi/block.json b/qapi/block.json
+index 22470e7..ceed7d6 100644
+--- a/qapi/block.json
++++ b/qapi/block.json
+@@ -300,3 +300,25 @@
+ ##
+ { 'command': 'xen-watch-device',
+   'data': { 'domid': 'int', 'devid': 'int', 'type': 'str', 'blocknode': 'str', 'devicename': 'str' } }
++
++##
++# @x-blockdev-suspend:
++#
++# Suspend blockdev
++#
++# @device: The device name or node name of the node to be suspended
++#
++##
++{ 'command': 'x-blockdev-suspend',
++'data': {'device': 'str'} }
++
++##
++# @x-blockdev-resume:
++#
++# Resume blockdev
++#
++# @device: The device name or node name of the node to be resumed
++#
++##
++{ 'command': 'x-blockdev-resume',
++'data': {'device': 'str'} }
+
+diff --git a/blockdev.c b/blockdev.c
+index 22fc540..d50e401 100644
+--- a/blockdev.c
++++ b/blockdev.c
+@@ -4042,6 +4042,47 @@ void qmp_x_blockdev_change(const char *parent, bool has_child,
+     }
+ }
+ 
++void qmp_x_blockdev_suspend(const char *device, Error **errp)
++{
++    BlockDriverState *bs = NULL;
++
++    bs = bdrv_lookup_bs(device, device, errp);
++    if (!bs) {
++        return;
++    }
++
++     while(bs->file) {
++         bs = bs->file->bs;
++     }
++
++    bdrv_drained_begin(bs); /* complete I/O */
++    bdrv_flush(bs);
++    bdrv_drain(bs); /* in case flush left pending I/O */
++
++    if (bs->drv) {
++        bs->drv->bdrv_close(bs);
++    }
++}
++
++void qmp_x_blockdev_resume(const char *device, Error **errp)
++{
++    BlockDriverState *bs = NULL;
++
++    bs = bdrv_lookup_bs(device, device, errp);
++    if (!bs) {
++        return;
++    }
++
++     while(bs->file) {
++         bs = bs->file->bs;
++     }
++
++    bs->drv->bdrv_file_open(bs, bs->options, bs->open_flags, errp);
++
++    bdrv_drained_end(bs);
++
++}
++
+ BlockJobInfoList *qmp_query_block_jobs(Error **errp)
+ {
+     BlockJobInfoList *head = NULL, **p_next = &head;

--- a/SPECS/qemu-dp.spec
+++ b/SPECS/qemu-dp.spec
@@ -101,6 +101,7 @@ Patch90: Use_the_legacy_grant_copy_ioctl
 
 # XCP-ng patches
 Patch1000: qemu-dp-2.10.2-add-rbd-support.XCP-ng.patch
+Patch1001: qemu-dp-2.10.2-add_x-blockdev-suspend_x-blockdev-resume_qmp_commands.XCP-ng.patch
 
 BuildRequires: libaio-devel glib2-devel
 BuildRequires: libjpeg-devel libpng-devel pixman-devel libdrm-devel
@@ -142,7 +143,10 @@ rm -rf %{buildroot}/usr/include %{buildroot}%{_libdir}/pkgconfig %{buildroot}%{_
 %{_libdir}/qemu-dp/bin
 
 %changelog
-* Thu Jul 05 2018 rposudnevskiy <ramzes_r@yahoo.com> - 2.10.2-1.2.1
+* Thu Jul 21 2018 rposudnevskiy <ramzes_r@yahoo.com> - 2.10.2-1.2.0
+- Add new QMP commands x-blockdev-suspend and x-blockdev-resume
+
+* Thu Jul 05 2018 rposudnevskiy <ramzes_r@yahoo.com> - 2.10.2-1.2.0
 - Enable support of Ceph RBD
 
 * Tue Apr 24 2018 marksy <mark.syms@citrix.com> - 2.10.2-1.2.0


### PR DESCRIPTION
Added new QMP commands for the ability to temporarily close and reopen images without rebuilding block devices (similar to 'tap-ctl pause' and
'tap-ctl unpause' in Blktap)

Added two commands:
  x-blockdev-suspend
  x-blockdev-resume